### PR TITLE
bugfix: Set item comments when parsing geeklists

### DIFF
--- a/boardgamegeek/loaders/geeklist.py
+++ b/boardgamegeek/loaders/geeklist.py
@@ -62,6 +62,6 @@ def add_geeklist_items_from_xml(geeklist, xml_root):
             "subtype": item.attrib["subtype"],
         }
         listitem.set_object(object_data)
-        add_geeklist_comments_from_xml(listitem, xml_root)
+        add_geeklist_comments_from_xml(listitem, item)
         added_items = True
     return added_items


### PR DESCRIPTION
When accessing a geeklist with comments enabled, the parsing of the XML structure was broken. It would always add the comments on the main Geeklist itself to every item in the list. This had the worse side-effect of losing all comments on the items themselves.

Fix the logic bug, so that every item's own comments are stored in its comments instance.