### PR TITLE
Update the API_ENDPOINT for Legacy API

### DIFF
--- a/boardgamegeek/legacy_api.py
+++ b/boardgamegeek/legacy_api.py
@@ -13,7 +13,7 @@ from .utils import request_and_parse_xml
 
 log = logging.getLogger("boardgamegeek.legacy_api")
 
-API_ENDPOINT = "https://www.boardgamegeek.com/xmlapi"
+API_ENDPOINT = "https://boardgamegeek.com/xmlapi"
 
 
 class BGGClientLegacy(BGGCommon):


### PR DESCRIPTION
BGG will send a redirect from www.boardgamegeek.com to boardgamegeek.com which causes the new Authorization Header to be stripped and hence the legacy API returns 401 errors. Fix this by using the correct base directly.

The new API implementation already uses the correct API base
